### PR TITLE
Add main entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ distribute-*.tar.gz
 # Mac OSX
 .DS_Store
 
+# Documentation build
+docs/build
+docs/generated
+
 # data files (should not be stored in git)
 **/wget*log*
 *.log
@@ -41,6 +45,9 @@ distribute-*.tar.gz
 *.par
 *.yml
 *.pdf
+Diffuse
+Photons
+spacecraft
 
 # Exclude from ignoring what we actually need
 !src/easyfermi/resources/ebl/*.fits.gz

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This will create the virtual environment and install all dependencies. Then acti
 <pre><code>sudo apt-get install libgl1</code></pre>
 
 - If you want, you can set _easyfermi_ as an environmental variable. For instance, if you use a Bash shell environment, you can open the `.bashrc` file in your home and set:
-<pre><code>alias easyfermi="mamba activate easyfermi && python -c 'import easyfermi'"</code></pre>
+<pre><code>alias easyfermi="mamba activate easyfermi && easyfermi"</code></pre>
 substituting _miniforge_ and _mamba_ by e.g. _anaconda_ and _conda_ if needed. This line of command depends on which distribution of Python you installed and how you set up the _mamba/conda_ environment.
 
 ### Cloning the repository installation
@@ -95,8 +95,8 @@ If you defined the variable _easyfermi_ in your shell environment (see **Install
 <pre><code>easyfermi</code></pre>
 
 Otherwise, type:
-<pre><code>mamba activate easyfermi</code></pre>
-<pre><code>python -c "import easyfermi"</code></pre>
+1. <pre><code>mamba activate easyfermi</code></pre>
+2. <pre><code>easyfermi</code></pre>
 
 Substituting _mamba_ by _conda_ if this is the case for you.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,10 +1,14 @@
+=====
 Usage
 =====
 
 .. _installation:
 
 Installation
-------------
+============
+
+Users
+-----
 
 To use ``easyfermi``, first install the fermitools environment using mamba (or conda):
 
@@ -29,12 +33,22 @@ Then activate the environment and install ``fermipy`` and ``easyfermi``:
 
 .. code-block:: console
 
-    $ alias easyfermi="mamba activate easyfermi && python -c 'import easyfermi'"
+    $ alias easyfermi="mamba activate easyfermi && easyfermi"
     
 substituting miniforge and mamba by e.g. anaconda and conda if needed. This line of command depends on which distribution of Python you installed and how you set up the mamba/conda environment.
 
+Developers
+----------
+
+1. create and activate the conda/mamba environment as for a released installation
+
+2. install `easyfermi` in editable mode with the developer extras (``pip install -e .[dev]``)
+
 Upgrading
-----------------
+=========
+
+Users
+-----
 
 You can check your currently installed version of easyfermi with pip show:
 
@@ -50,8 +64,22 @@ If you have **easyfermi 2.0.X** installed, upgrade your installation to the late
     
 If instead, you have **easyfermi 1.X.X** installed, please install easyfermi V2 following section :ref:`installation`.
 
+Developers
+----------
+
+1. commit, stash or revert any pending changes
+2. switch to the default branch (``git switch main``)
+3. pull the latest changes (``git pull``)
+4. re-install the package in editable mode with the developer extras (``pip install -e .[dev]``)
+
+.. important::
+
+    If you are working from a forked repository
+    make sure to pull from the upstream default branch
+    and not yours.
+
 Uninstalling
-----------------
+============
 
 In the terminal, run:
 
@@ -62,7 +90,7 @@ In the terminal, run:
 
 
 Running
-----------------
+=======
 
 If you defined the variable *easyfermi* in your shell environment (see :ref:`installation`), simply type the following in the terminal:
 
@@ -75,7 +103,7 @@ Otherwise, type:
 .. code-block:: console
 
     $ mamba activate easyfermi
-    $ python -c "import easyfermi"
+    $ easyfermi
     
 Substituting mamba by conda if this is the case for you.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ where = ["src"]
 dev = ["easyfermi[docs]", "easyfermi[tests]", "ruff", "pre-commit"]
 
 [project.scripts]
-my-script = "my_package.module:function"
+easyfermi = "easyfermi.easyfermi:main"
 
 # ... other project metadata fields as listed in:
 #     https://packaging.python.org/en/latest/guides/writing-pyproject-toml/

--- a/src/easyfermi/__init__.py
+++ b/src/easyfermi/__init__.py
@@ -1,4 +1,1 @@
 """The easiest way to analyze Fermi-LAT data."""
-
-from .easyfermi import *
-

--- a/src/easyfermi/easyfermi.py
+++ b/src/easyfermi/easyfermi.py
@@ -104,38 +104,41 @@ class Worker(QtCore.QObject):
     finished_download_photons = QtCore.pyqtSignal()
     progress = QtCore.pyqtSignal(int)
     
+    def __init__(self, ui):
+
+        self.ui = ui
     
     def run_gtsetup(self):
         """Long-running task."""
         self.starting.emit()
-        ui.setFermipy()
+        self.ui.setFermipy()
         self.progress.emit(0)  # These numbers 0, 1, 2 etc defined by emit() enter as "n" in the function reportProgress(self,n)
-        ui.gta.setup()
+        self.ui.gta.setup()
         self.progress.emit(1)
-        N_iter_adaptive_LC = ui.analysisBasics()
+        N_iter_adaptive_LC = self.ui.analysisBasics()
         self.progress.emit(2)
-        calculate_Sun = ui.fit_model()
+        calculate_Sun = self.ui.fit_model()
         if calculate_Sun:
             self.progress.emit(3)
-            ui.Sun_path()
+            self.ui.Sun_path()
 
         self.progress.emit(4)
-        ui.relocalize_the_target()
+        self.ui.relocalize_the_target()
         self.progress.emit(5)
-        ui.compute_TSmap()
+        self.ui.compute_TSmap()
         self.progress.emit(6)
-        ui.compute_Extension()
+        self.ui.compute_Extension()
         self.progress.emit(7)
-        ui.compute_SED()
+        self.ui.compute_SED()
         self.progress.emit(8)
-        ui.EBL_and_MCMC()
+        self.ui.EBL_and_MCMC()
         self.progress.emit(9)
-        ui.compute_LC()
-        ui.plot_LCs(adaptive=False)
+        self.ui.compute_LC()
+        self.ui.plot_LCs(adaptive=False)
         self.progress.emit(10)
         for i in range(N_iter_adaptive_LC):
-            ui.compute_LC_adaptive()
-        ui.plot_LCs(adaptive=True)
+            self.ui.compute_LC_adaptive()
+        self.ui.plot_LCs(adaptive=True)
         self.progress.emit(11)
         self.finished.emit()
 
@@ -1335,7 +1338,7 @@ class Ui_mainWindow(QDialog):
         
         if can_we_go:
             self.thread = QtCore.QThread()
-            self.worker = Worker()
+            self.worker = Worker(self)
             self.worker.moveToThread(self.thread)
         
             # Standard or custom analysis?
@@ -4022,17 +4025,20 @@ class Ui_mainWindow(QDialog):
 
     
 
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+    mainWindow = QtWidgets.QMainWindow()
+    ui = Ui_mainWindow()
+    ui.setupUi(mainWindow)
+    mainWindow.show()
+    sys.exit(app.exec_())
 
 
 
+if __name__ == "__main__":
 
-#if __name__ == "__main__":
-app = QtWidgets.QApplication(sys.argv)
-mainWindow = QtWidgets.QMainWindow()
-ui = Ui_mainWindow()
-ui.setupUi(mainWindow)
-mainWindow.show()
-sys.exit(app.exec_())
+    main()
+
 
 
 


### PR DESCRIPTION
This PR defines a `main` function and an entry point named as the package "easyfermi".

After this PR it should be possible to launch _easyfermi_ from the command line typing simply `easyfermi`, without the need of importing the whole package.

I updated the README and the documentation accordingly.

Unfortunately at the moment I can't yet test the software rigorously to see if I broke something because of #37 (and #45).